### PR TITLE
Removed if statement which stops aspnet projects from working

### DIFF
--- a/DevAudit.AuditLibrary/Targets/PackageSource.cs
+++ b/DevAudit.AuditLibrary/Targets/PackageSource.cs
@@ -374,6 +374,12 @@ namespace DevAudit.AuditLibrary
                 pv.Value.AsParallel().ForAll((vulnerability) =>
                 {
                     List<Package> packages = this.Packages.Where(p => p.PackageManager == vulnerability.Package.PackageManager && p.Name == vulnerability.Package.Name).ToList();
+
+                    for (int i = 0; i < vulnerability.Versions.Length; i++)
+                    {
+                        vulnerability.Versions[i] = Uri.UnescapeDataString(vulnerability.Versions[i]);
+                    }
+
                     foreach (Package p in packages)
                     {
                         try

--- a/DevAudit.AuditLibrary/Targets/PackageSource.cs
+++ b/DevAudit.AuditLibrary/Targets/PackageSource.cs
@@ -40,11 +40,11 @@ namespace DevAudit.AuditLibrary
                     throw new ArgumentException(string.Format("No file option was specified and the default {0} package sourcs configuration file {1} was not found.", this.PackageManagerLabel, this.DefaultPackageManagerConfigurationFile));
                 }
             }
-            else if (!this.PackageSourceOptions.ContainsKey("File") && this.DefaultPackageManagerConfigurationFile == string.Empty)
-            {
-                throw new ArgumentException(string.Format("No file option was specified and the {0} package source " 
-                    + "does not specify a default configuration file.", this.PackageManagerLabel));
-            }
+            //else if (!this.PackageSourceOptions.ContainsKey("File") && this.DefaultPackageManagerConfigurationFile == string.Empty)
+            //{
+            //    throw new ArgumentException(string.Format("No file option was specified and the {0} package source " 
+            //        + "does not specify a default configuration file.", this.PackageManagerLabel));
+            //}
 
             if (!string.IsNullOrEmpty(this.PackageManagerConfigurationFile))
             {


### PR DESCRIPTION
This statement stops aspnet projects from working with the following options.  Have removed it so I can get it through on v3.

devaudit aspnet --ci -r c:\ProjectsFolder -b @bin\MyProject.dll