### PR TITLE
Changes Console.Write(format, args) to use PrintMessageformat, args)

### DIFF
--- a/DevAudit.CommandLine/Program.cs
+++ b/DevAudit.CommandLine/Program.cs
@@ -1021,7 +1021,7 @@ static void EnvironmentMessageHandler(object sender, EnvironmentEventArgs e)
             }
             else
             {
-                Console.Write(format, args);
+                PrintMessage(format, args);
             }
         }
 
@@ -1032,7 +1032,7 @@ static void EnvironmentMessageHandler(object sender, EnvironmentEventArgs e)
 
         static void PrintMessageLine(string format, params object[] args)
         {
-            Console.WriteLine(format, args);
+            PrintMessage(format, args);
         }
 
         static void PrintMessageLine(ConsoleColor color, string format, params object[] args)


### PR DESCRIPTION
Had an exception thrown when using console.write(format, args) when a vulnerability with jQuery 3.3.1 appeared in our audits:

"If an unsanitized source object contained an enumerable __proto__ property, it could extend the native Object.prototype."

Changing line 1024 to use PrintMessage(format, args) fixed the problem. I've changed line 1035 to use PrintMessage() for consistency.