### PR TITLE
Fixing bug where nuget packages are not correctly located when an XML…

### DIFF
--- a/DevAudit.AuditLibrary/Examples/project.1.csproj
+++ b/DevAudit.AuditLibrary/Examples/project.1.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <LangVersion>7.1</LangVersion>

--- a/DevAudit.AuditLibrary/PackageSources/NetCorePackageSource.cs
+++ b/DevAudit.AuditLibrary/PackageSources/NetCorePackageSource.cs
@@ -45,19 +45,19 @@ namespace DevAudit.AuditLibrary
                 }
                 XElement root = XElement.Parse(xml);
 
-                if (root.Name == "Project")
+                if (root.Name.LocalName == "Project")
                 {
                     packages = 
                         root
                         .Descendants()
-                        .Where(x => x.Name == "PackageReference" && x.Attribute("Include") != null && x.Attribute("Version") != null)
+                        .Where(x => x.Name.LocalName == "PackageReference" && x.Attribute("Include") != null && x.Attribute("Version") != null)
                         .SelectMany(r => GetDeveloperPackages(r.Attribute("Include").Value, r.Attribute("Version").Value))
                         .ToList();
 
                     IEnumerable<string> skipped_packages = 
                         root
                         .Descendants()
-                        .Where(x => x.Name == "PackageReference" && x.Attribute("Include") != null && x.Attribute("Version") == null)
+                        .Where(x => x.Name.LocalName == "PackageReference" && x.Attribute("Include") != null && x.Attribute("Version") == null)
                         .Select(r => r.Attribute("Include").Value);
                         
                     if (skipped_packages.Count() > 0)

--- a/DevAudit.AuditLibrary/PackageSources/NuGetv2PackageSource.cs
+++ b/DevAudit.AuditLibrary/PackageSources/NuGetv2PackageSource.cs
@@ -42,13 +42,13 @@ namespace DevAudit.AuditLibrary
             
             IEnumerable<Package> packages;
 
-            if (root.Name == "Project")
+            if (root.Name.LocalName == "Project")
             {
                 // dotnet core csproj file
                 packages = 
                     root
                     .Descendants()
-                    .Where(x => x.Name == "PackageReference")
+                    .Where(x => x.Name.LocalName == "PackageReference")
                     .SelectMany(r => GetDeveloperPackages(r.Attribute("Include").Value, r.Attribute("Version").Value)).ToList();
             }
             else


### PR DESCRIPTION
When the root XML element in a .csproj file contains an XMLNS attribute, nuget packages are not correctly located. 

Fixed the issue by referencing the LocalName of the XML element, which excludes any namespace.